### PR TITLE
Remove alert tab

### DIFF
--- a/R_scripts/TEMPESTdash/server.R
+++ b/R_scripts/TEMPESTdash/server.R
@@ -216,7 +216,7 @@ server <- function(input, output) {
     #                 selected = "Freshwater")
     # })
 
-    output$table <- renderDataTable(datatable({
+    output$sapflow_table <- DT::renderDataTable(datatable({
         autoInvalidate()
         sapflow_data <- reactive_df()$sapflow
 
@@ -240,6 +240,8 @@ server <- function(input, output) {
             )
 
     }))
+
+    output$y11 <- renderPrint(input$sapflow_table_rows_selected)
 
      output$teros_table <- renderDataTable({
 

--- a/R_scripts/TEMPESTdash/ui.R
+++ b/R_scripts/TEMPESTdash/ui.R
@@ -64,7 +64,8 @@ ui <- dashboardPage(
             ),
                       tabItem(
                           tabName = "sapflow",
-                          dataTableOutput("table"),
+                          DT::dataTableOutput("sapflow_table"),
+                          verbatimTextOutput("y11"),
                           selectInput("plot",
                                       "Plot:",
                                       choices = c("Control", "Freshwater", "Seawater", "Shoreline"),
@@ -83,20 +84,20 @@ ui <- dashboardPage(
                           dataTableOutput("btable")#,
                           # actionButton("press", "press me"),
                           # textOutput("number")
-                      ),
-            tabItem(
-                tabName = "alerts",
-                textInput(inputId = "phone-number",
-                          label = "Phone number:",
-                          value = "(301) 555-5555"),
-
-                # Input: Selector for choosing dataset ----
-                selectInput(inputId = "carrier",
-                            label = "Select your carrier:",
-                            choices = c("Verizon", "AT&T", "T Mobile")),
-
-                submitButton("Receive Text Alerts")
-            )
+                      )#,
+            # tabItem(
+            #     tabName = "alerts",
+            #     textInput(inputId = "phone-number",
+            #               label = "Phone number:",
+            #               value = "(301) 555-5555"),
+            #
+            #     # Input: Selector for choosing dataset ----
+            #     selectInput(inputId = "carrier",
+            #                 label = "Select your carrier:",
+            #                 choices = c("Verizon", "AT&T", "T Mobile")),
+            #
+            #     submitButton("Receive Text Alerts")
+            # )
 
         )
     )


### PR DESCRIPTION
@stephpenn1 

This took SO LONG TO FIND 😞 

I don't understand why, but the "alerts" dashboard tab was breaking the DT row selection.

This PR adds a simple printout of selected rows, and disables that alert tab.

<img width="540" alt="Screen Shot 2022-06-20 at 9 53 52 PM" src="https://user-images.githubusercontent.com/1956468/174700083-3abfbd41-0bee-4819-b19c-d092460f38bc.png">

